### PR TITLE
[techlag] Support extensibility

### DIFF
--- a/bin/techlag
+++ b/bin/techlag
@@ -22,72 +22,49 @@
 #
 
 import argparse
-import logging
 import sys
 
-from techlag.techlag import TechLag
+from techlag.techlag import find_backends
+from techlag import backends
+
+TECHLAG_USAGE_MSG = \
+"""%(prog)s [-g] <backend> [<args>] | --help | --version"""
 
 
-def get_params_parser():
-    """Parse command line arguments
+def parse_args():
+    """Parse command line arguments"""
 
-    Valid arguments are:
-        -h, --help: summary about how to use the tool
-        -p, --package: package name
-        -v, --version: package version
-        -k, --kind: target dependencies kind: devDependencies or dependencies
-        -j, --json: package.json URI
-    """
-
-    parser = argparse.ArgumentParser(usage='',
+    parser = argparse.ArgumentParser(usage=TECHLAG_USAGE_MSG,
                                      description='',
                                      epilog='',
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      add_help=False)
 
-    parser.add_argument('-h', '--help', action='help', help=argparse.SUPPRESS)
-    parser.add_argument('-p', '--package', dest='package', help="package name")
-    parser.add_argument('-v', '--version', dest='version', help="package version or constraint")
-    parser.add_argument('-k', '--kind', dest='kind', help="target dependencies kind: devDependencies or dependencies")
-    parser.add_argument('-j', '--json', dest='pjson', help="package.json URL")
+    parser.add_argument('-h', '--help', action='help',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('backend', help=argparse.SUPPRESS)
+    parser.add_argument('backend_args', nargs=argparse.REMAINDER,
+                        help=argparse.SUPPRESS)
 
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
 
-    return parser
-
-
-def get_params():
-
-    parser = get_params_parser()
-    args = parser.parse_args()
-
-    msg = "Please enter one of the following commands:\n" \
-          "(1) --package <p> --version <v> --kind <k>,\n" \
-          "(2) --json <package.json path> --kind <k>,\n" \
-          "(3) --help"
-
-    if args.pjson and args.kind:
-        if args.package or args.version:
-            logging.error(msg)
-            sys.exit(1)
-    elif args.package and args.version and args.kind:
-        if args.pjson:
-            logging.error(msg)
-            sys.exit(1)
-
-    return args
+    return parser.parse_args()
 
 
 def main():
-    args = get_params()
+    args = parse_args()
 
-    try:
-        tl = TechLag(args.package, args.version, args.kind, args.pjson)
-        tl.analyze()
-    except Exception as e:
-        logging.error(e, exc_info=True)
+    _, TECHLAG_CMDS = find_backends(backends)
+
+    if args.backend not in TECHLAG_CMDS:
+        raise RuntimeError("Unknown backend %s" % args.backend)
+
+    klass = TECHLAG_CMDS[args.backend]
+    cmd = klass(*args.backend_args)
+    cmd.run()
 
 
 if __name__ == '__main__':

--- a/techlag/backends/npm.py
+++ b/techlag/backends/npm.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import logging
+import pandas as pd
+from urllib.parse import urljoin
+
+from techlag.errors import (ParamsError,
+                            TechLagError)
+from techlag.techlag import (TechLag,
+                             TechLagCommand,
+                             TechLagCommandArgumentParser,
+                             RELEASE_PATCH,
+                             RELEASE_MINOR,
+                             RELEASE_MAJOR)
+
+DEPENDENCIES_KIND = "dependencies"
+DEV_DEPENDENCIES_KIND = "devDependencies"
+DEPENDENCIES = [DEPENDENCIES_KIND, DEV_DEPENDENCIES_KIND]
+
+NPM_URL = 'http://registry.npmjs.org'
+
+logger = logging.getLogger(__name__)
+
+
+class Npm(TechLag):
+    """Npm backend.
+
+    This class allows to calculate the technical lag for Npm packages. It can be
+    executed in two ways, either:
+        - the package name, version and kind of dependencies to analyze
+        - the URI of a package.json plus the kind of dependencies to analyze
+    Possible examples of executions are:
+        - Npm(pjson=https://raw.githubusercontent.com/jasmine/jasmine/master/package.json,
+                  kind='devDependencies")
+        - Npm(package="grunt", version="1.0.0", kind="dependencies")
+
+    :param package: target package name
+    :param version: the target package version
+    :param url: the URL of the package.json
+    :param dep_kind: kind of dependencies to analyze
+    """
+
+    version = '0.1.0'
+
+    def __init__(self, package=None, version=None, url=None, dep_kind=None):
+        super().__init__(package, version, url)
+
+        if not dep_kind and not url:
+            raise ParamsError(cause="kind of dependencies cannot be null")
+
+        if package and version and dep_kind:
+            if url:
+                raise ParamsError(cause="too many parameters passed, "
+                                        "set <package, version, dep_kind> or <url>")
+
+        if url:
+            if package or version:
+                raise ParamsError(cause="too many parameters passed, "
+                                        "set <package, version, dep_kind> or <url>")
+
+        if dep_kind not in DEPENDENCIES:
+            logger.warning("Unknown dependency kind, set it to %s", DEPENDENCIES_KIND)
+            dep_kind = DEPENDENCIES_KIND
+
+        self.dep_kind = dep_kind
+
+    def analyze(self):
+        """Calculate the technical lag for the target package"""
+
+        if self.url:
+            json = TechLag.fetch_from_url(self.url)
+        else:
+            version = self.semver(self.version, self.get_versions(self.package).version.tolist())[-1]
+            url = urljoin(NPM_URL, self.package + '/' + version)
+            json = TechLag.fetch_from_url(url)
+
+        if self.dep_kind not in json:
+            msg = "%s package.json doesn't contain information about %s" % (json['name'], self.dep_kind)
+            logger.error(msg)
+            raise TechLagError(cause=msg)
+
+        dependencies = self.get_dependencies(json, self.dep_kind)
+        result = self.calculate_lags(dependencies)
+
+        return result
+
+    def calculate_lags(self, dependencies):
+        """Calculate technical lag for a list of dependencies.
+
+        :param dependencies: pandas data frame of package dependencies
+
+        :return: the dependencies with the corresponding technical lag
+        """
+        dependencies['used_version'] = ''
+        dependencies['latest_version'] = ''
+        dependencies[RELEASE_MAJOR + '_lag'] = ''
+        dependencies[RELEASE_MINOR + '_lag'] = ''
+        dependencies[RELEASE_PATCH + '_lag'] = ''
+
+        for row in range(0, len(dependencies)):
+            list_versions = self.get_versions(dependencies.iloc[row].dependency)
+
+            latest = self.semver('*', list_versions.version.tolist())[-1]
+            used = self.semver(dependencies.iloc[row].constraint, list_versions.version.tolist())[-1]
+
+            lag = self.compute_lag(list_versions, used, latest)
+
+            dependencies.latest_version.iloc[row] = latest
+            dependencies.used_version.iloc[row] = used
+            dependencies.major_lag.iloc[row] = lag[RELEASE_MAJOR]
+            dependencies.minor_lag.iloc[row] = lag[RELEASE_MINOR]
+            dependencies.patch_lag.iloc[row] = lag[RELEASE_PATCH]
+
+        return dependencies
+
+    @staticmethod
+    def get_dependencies(package, kind):
+        """Get the dependencies of a given kind for a target package.json.
+
+        :param package: package information in JSON format
+        :param kind: kind of dependencies to analyze
+
+        :return: a pandas data frame with the dependencies
+        """
+        dependencies = (pd.DataFrame({'dependency': list(package[kind].keys()),
+                                      'constraint': list(package[kind].values()),
+                                      'kind': kind}))
+
+        return dependencies
+
+    @staticmethod
+    def get_versions(package):
+        """Get the version of a given package.
+
+        :param package: target package name
+
+        :return: pandas data frame of package versions
+        """
+        url = urljoin(NPM_URL, package)
+        versions = TechLag.fetch_from_url(url)['time']
+        versions.pop('modified')
+        versions.pop('created')
+        versions = (pd.DataFrame({'version': list(versions.keys()),
+                                  'date': list(versions.values()),
+                                  'package': package}))
+
+        return versions
+
+    @staticmethod
+    def compute_lag(versions, used, latest):
+        """Compute the technical lag for the set of versions of a given package.
+
+        :param versions: pandas data frame of the package versions
+        :param used: version in use of the package
+        :param latest: latest version available of the package
+
+        :return: the technical lag
+        """
+        used = TechLag.convert_version(used.split('-')[0])
+        latest = TechLag.convert_version(latest.split('-')[0])
+
+        if used == latest:
+            return {RELEASE_MAJOR: 0, RELEASE_MINOR: 0, RELEASE_PATCH: 0}
+
+        versions['version'] = versions['version'].apply(lambda x: x.split('-')[0])
+        versions = versions.drop_duplicates()
+
+        versions['version_count'] = versions['version'].apply(lambda x: TechLag.convert_version(x))
+        versions.sort_values('version_count', ascending=True, inplace=True)
+
+        versions['version_old'] = versions['version'].shift(1)
+        versions['release_type'] = versions.apply(lambda d: TechLag.release_type(d['version_old'],
+                                                                                 d['version']),
+                                                  axis=1)
+        versions = versions.query('version_count>' + str(used) + ' and version_count <= ' + str(latest))
+
+        lag = versions.groupby('release_type').count()[['version']].to_dict()['version']
+
+        if RELEASE_MAJOR not in lag.keys():
+            lag[RELEASE_MAJOR] = 0
+        if RELEASE_MINOR not in lag.keys():
+            lag[RELEASE_MINOR] = 0
+        if RELEASE_PATCH not in lag.keys():
+            lag[RELEASE_PATCH] = 0
+
+        return lag
+
+
+class NpmCommand(TechLagCommand):
+    """Class to run Npm backend from the command line."""
+
+    BACKEND = Npm
+
+    @staticmethod
+    def setup_cmd_parser():
+        """Returns the GitLab argument parser."""
+
+        parser = TechLagCommandArgumentParser()
+
+        # Npm options
+        group = parser.parser.add_argument_group('Npm arguments')
+        group.add_argument('-k', '--dependencies-kind', dest='dep_kind',
+                           help="Kind of dependencies to analyze: devDependencies or dependencies")
+
+        return parser

--- a/techlag/errors.py
+++ b/techlag/errors.py
@@ -42,3 +42,9 @@ class ParamsError(BaseError):
     """Generic error for params errors"""
 
     message = "%(cause)s"
+
+
+class TechLagError(BaseError):
+    """Generic error for TechLag errors"""
+
+    message = "%(cause)s"

--- a/tests/test_npm.py
+++ b/tests/test_npm.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import unittest
+
+from techlag.backends.npm import (Npm,
+                                  logger,
+                                  DEPENDENCIES_KIND,
+                                  DEV_DEPENDENCIES_KIND)
+from techlag.errors import ParamsError
+
+
+class TestNpm(unittest.TestCase):
+    """Npm backend tests"""
+
+    def test_init(self):
+        """Test whether the attributes are initialized"""
+
+        backend = Npm(package="grunt", version="1.0.0", dep_kind=DEPENDENCIES_KIND)
+        self.assertEqual(backend.package, "grunt")
+        self.assertEqual(backend.version, "1.0.0")
+        self.assertEqual(backend.dep_kind, "dependencies")
+
+        backend = Npm(url="https://raw.githubusercontent.com/jasmine/jasmine/master/package.json",
+                      dep_kind=DEV_DEPENDENCIES_KIND)
+        self.assertEqual(backend.url, "https://raw.githubusercontent.com/jasmine/jasmine/master/package.json")
+        self.assertEqual(backend.dep_kind, DEV_DEPENDENCIES_KIND)
+
+        with self.assertRaises(ParamsError):
+            Npm(package="grunt", version="1.0.0")
+
+        with self.assertRaises(ParamsError):
+            Npm(package="grunt", version="1.0.0", dep_kind=DEV_DEPENDENCIES_KIND, url="https://...")
+
+        with self.assertRaises(ParamsError):
+            Npm(package="grunt", dep_kind=DEV_DEPENDENCIES_KIND, url="https://...")
+
+        with self.assertLogs(logger, level='INFO') as cm:
+            Npm(dep_kind="unknown_dev", url="https://...")
+            self.assertEqual(cm.output[0], "WARNING:techlag.backends.npm:Unknown dependency kind, "
+                                           "set it to dependencies")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR provides a mechanism to easily extend `TechLag` to different package managers (beyond Npm, the already supported one). In a nutshell, every backend can be initialized with a combination of the following parameters: `package`, `version` or `url`, and needs to implement the `analyze` method (which is in charge of calculating the technical lag.

To show the feasibility of the approach, a backend to assess the technical lag of Npm packages is proposed (it is derived from the previous implementation of TechLag).